### PR TITLE
Update signbuild.sh

### DIFF
--- a/android/signbuild/signbuild.sh
+++ b/android/signbuild/signbuild.sh
@@ -44,7 +44,7 @@ else
  fi
  echo '==> Target filename is '"$TARGETZIP"
  echo "=> Making target files package..."
- mka -j$(nproc --all) target-files-package dist &&
+ make -j$(nproc --all) target-files-package dist &&
  printf "=> Signing apks... "
  TARGET=$(ls -tr1 out/dist | tail -1)
  printf "(target from $TARGET)\n"


### PR DESCRIPTION
On line 47, changed 'mka' to 'make'.

Been trying to build LOS 16 for harpia and got the following error:
  ==> Target filename is -.zip
  => Making target files package...
  bash: mka: command not found

Changed 'mka' to 'make' and seemed to fix it. Still learning, so please forgive me if this fix is wrong.

Thanks for all your work on harpia!